### PR TITLE
Fix printsOutput() behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ $reflection->containsInlineHtml();
 $reflection->containsPhpCode();
 // true if the file contains echo or print statements
 $reflection->printsOutput();
+// true if the file contains functions (not methods)
+$reflection->containsFunctions();
 
 try {
     // returns the namespace as a string, throws exception if the
@@ -50,6 +52,15 @@ try {
 } catch (ReflectionException $exception) {
     var_dump("The class does not contain a class!");
 }
+
+// returns array with \ReflectionFunction instances
+// can throw exception if the functions could not be found
+// which happnes when the file is not included
+foreach ($reflection->getFunctions() as $function) {
+    var_dump("Function name: {$function->getName()}");
+    
+}
+
 ```
 
 ## Limitations

--- a/tests/Data/ClassWithEchoStatement.php
+++ b/tests/Data/ClassWithEchoStatement.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Rikudou\Tests\Data;
+
+class ClassWithEchoStatement
+{
+    public function hello()
+    {
+        echo 'there';
+        $this->saySomething();
+    }
+
+    private function saySomething()
+    {
+        echo 'hello';
+    }
+}

--- a/tests/Data/FunctionsFile.php
+++ b/tests/Data/FunctionsFile.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Rikudou\Tests\Data;
+
+function myFunction1()
+{
+    echo 'hello';
+}
+
+function myFunction2()
+{
+    {
+        // nested block to test the brace counting
+    }
+}

--- a/tests/Data/InlineHtmlFile.php
+++ b/tests/Data/InlineHtmlFile.php
@@ -1,4 +1,4 @@
 Hello there
 <?php
 
-echo "Hello";
+echo 'Hello';

--- a/tests/Data/NamespacedClass.php
+++ b/tests/Data/NamespacedClass.php
@@ -4,5 +4,4 @@ namespace Rikudou\Tests\Data;
 
 class NamespacedClass
 {
-
 }

--- a/tests/Data/NonNamespacedClass.php
+++ b/tests/Data/NonNamespacedClass.php
@@ -2,5 +2,4 @@
 
 class NonNamespacedClass
 {
-
 }

--- a/tests/Data/OutputPrintingFile.php
+++ b/tests/Data/OutputPrintingFile.php
@@ -1,4 +1,3 @@
 <?php
 
-echo "Hello there";
-
+echo 'Hello there';

--- a/tests/ReflectionFileTest.php
+++ b/tests/ReflectionFileTest.php
@@ -11,23 +11,23 @@ namespace Rikudou\Tests;
 use PHPUnit\Framework\TestCase;
 use Rikudou\Exception\ReflectionException;
 use Rikudou\ReflectionFile;
+use Rikudou\Tests\Data\ClassWithEchoStatement;
 use Rikudou\Tests\Data\NamespacedClass;
 
 class ReflectionFileTest extends TestCase
 {
-
     public static function setUpBeforeClass(): void
     {
         ob_start();
         $files = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator(
-                __DIR__ . "/Data"
+                __DIR__ . '/Data'
             )
         );
 
         foreach ($files as $file) {
             assert($file instanceof \SplFileInfo);
-            if ($file->isFile() && $file->getExtension() === "php") {
+            if ($file->isFile() && $file->getExtension() === 'php') {
                 require_once $file->getRealPath();
             }
         }
@@ -42,6 +42,7 @@ class ReflectionFileTest extends TestCase
 
     public function testContainsInlineHtml()
     {
+        $this->assertFalse($this->getClassWithEchoStatementFile()->containsInlineHtml());
         $this->assertTrue($this->getInlineHtmlFile()->containsInlineHtml());
         $this->assertFalse($this->getNamespacedClassFile()->containsInlineHtml());
         $this->assertFalse($this->getNonNamespacedClassFile()->containsInlineHtml());
@@ -51,6 +52,7 @@ class ReflectionFileTest extends TestCase
 
     public function testContainsClass()
     {
+        $this->assertTrue($this->getClassWithEchoStatementFile()->containsClass());
         $this->assertFalse($this->getInlineHtmlFile()->containsClass());
         $this->assertTrue($this->getNamespacedClassFile()->containsClass());
         $this->assertTrue($this->getNonNamespacedClassFile()->containsClass());
@@ -60,22 +62,27 @@ class ReflectionFileTest extends TestCase
 
     public function testGetNamespace()
     {
+        $this->assertEquals('Rikudou\Tests\Data', $this->getClassWithEchoStatementFile()->getNamespace());
+
         try {
             $this->getInlineHtmlFile()->getNamespace();
             $this->fail('Expected exception');
         } catch (ReflectionException $e) {
         }
         $this->assertEquals('Rikudou\Tests\Data', $this->getNamespacedClassFile()->getNamespace());
+
         try {
             $this->getNonNamespacedClassFile()->getNamespace();
             $this->fail('Expected exception');
         } catch (ReflectionException $e) {
         }
+
         try {
             $this->getNonPhpContentFile()->getNamespace();
             $this->fail('Expected exception');
         } catch (ReflectionException $e) {
         }
+
         try {
             $this->getOutputPrintingFile()->getNamespace();
             $this->fail('Expected exception');
@@ -85,6 +92,7 @@ class ReflectionFileTest extends TestCase
 
     public function testPrintsOutput()
     {
+        $this->assertFalse($this->getClassWithEchoStatementFile()->printsOutput());
         $this->assertTrue($this->getInlineHtmlFile()->printsOutput());
         $this->assertFalse($this->getNamespacedClassFile()->printsOutput());
         $this->assertFalse($this->getNonNamespacedClassFile()->printsOutput());
@@ -94,6 +102,7 @@ class ReflectionFileTest extends TestCase
 
     public function testContainsNamespace()
     {
+        $this->assertTrue($this->getClassWithEchoStatementFile()->containsNamespace());
         $this->assertFalse($this->getInlineHtmlFile()->containsNamespace());
         $this->assertTrue($this->getNamespacedClassFile()->containsNamespace());
         $this->assertFalse($this->getNonNamespacedClassFile()->containsNamespace());
@@ -103,6 +112,7 @@ class ReflectionFileTest extends TestCase
 
     public function testContainsPhpCode()
     {
+        $this->assertTrue($this->getClassWithEchoStatementFile()->containsPhpCode());
         $this->assertTrue($this->getInlineHtmlFile()->containsPhpCode());
         $this->assertTrue($this->getNamespacedClassFile()->containsPhpCode());
         $this->assertTrue($this->getNonNamespacedClassFile()->containsPhpCode());
@@ -112,6 +122,8 @@ class ReflectionFileTest extends TestCase
 
     public function testGetClass()
     {
+        $this->assertEquals(ClassWithEchoStatement::class, $this->getClassWithEchoStatementFile()->getClass()->getName());
+
         try {
             $this->getInlineHtmlFile()->getClass();
             $this->fail('Expected exception');
@@ -119,17 +131,23 @@ class ReflectionFileTest extends TestCase
         }
         $this->assertEquals(NamespacedClass::class, $this->getNamespacedClassFile()->getClass()->getName());
         $this->assertEquals(\NonNamespacedClass::class, $this->getNonNamespacedClassFile()->getClass()->getName());
+
         try {
             $this->getNonPhpContentFile()->getClass();
             $this->fail('Expected exception');
         } catch (ReflectionException $e) {
         }
+
         try {
             $this->getOutputPrintingFile()->getClass();
             $this->fail('Expected exception');
         } catch (ReflectionException $e) {
         }
+    }
 
+    private function getClassWithEchoStatementFile()
+    {
+        return $this->getReflection('ClassWithEchoStatement.php');
     }
 
     private function getInlineHtmlFile()

--- a/tests/ReflectionFileTest.php
+++ b/tests/ReflectionFileTest.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: root
- * Date: 6.2.19
- * Time: 23:11
- */
 
 namespace Rikudou\Tests;
 
@@ -43,6 +37,7 @@ class ReflectionFileTest extends TestCase
     public function testContainsInlineHtml()
     {
         $this->assertFalse($this->getClassWithEchoStatementFile()->containsInlineHtml());
+        $this->assertFalse($this->getFunctionsFile()->containsInlineHtml());
         $this->assertTrue($this->getInlineHtmlFile()->containsInlineHtml());
         $this->assertFalse($this->getNamespacedClassFile()->containsInlineHtml());
         $this->assertFalse($this->getNonNamespacedClassFile()->containsInlineHtml());
@@ -53,6 +48,7 @@ class ReflectionFileTest extends TestCase
     public function testContainsClass()
     {
         $this->assertTrue($this->getClassWithEchoStatementFile()->containsClass());
+        $this->assertFalse($this->getFunctionsFile()->containsClass());
         $this->assertFalse($this->getInlineHtmlFile()->containsClass());
         $this->assertTrue($this->getNamespacedClassFile()->containsClass());
         $this->assertTrue($this->getNonNamespacedClassFile()->containsClass());
@@ -63,6 +59,7 @@ class ReflectionFileTest extends TestCase
     public function testGetNamespace()
     {
         $this->assertEquals('Rikudou\Tests\Data', $this->getClassWithEchoStatementFile()->getNamespace());
+        $this->assertEquals('Rikudou\Tests\Data', $this->getFunctionsFile()->getNamespace());
 
         try {
             $this->getInlineHtmlFile()->getNamespace();
@@ -93,6 +90,7 @@ class ReflectionFileTest extends TestCase
     public function testPrintsOutput()
     {
         $this->assertFalse($this->getClassWithEchoStatementFile()->printsOutput());
+        $this->assertFalse($this->getFunctionsFile()->printsOutput());
         $this->assertTrue($this->getInlineHtmlFile()->printsOutput());
         $this->assertFalse($this->getNamespacedClassFile()->printsOutput());
         $this->assertFalse($this->getNonNamespacedClassFile()->printsOutput());
@@ -103,6 +101,7 @@ class ReflectionFileTest extends TestCase
     public function testContainsNamespace()
     {
         $this->assertTrue($this->getClassWithEchoStatementFile()->containsNamespace());
+        $this->assertTrue($this->getFunctionsFile()->containsNamespace());
         $this->assertFalse($this->getInlineHtmlFile()->containsNamespace());
         $this->assertTrue($this->getNamespacedClassFile()->containsNamespace());
         $this->assertFalse($this->getNonNamespacedClassFile()->containsNamespace());
@@ -113,6 +112,7 @@ class ReflectionFileTest extends TestCase
     public function testContainsPhpCode()
     {
         $this->assertTrue($this->getClassWithEchoStatementFile()->containsPhpCode());
+        $this->assertTrue($this->getFunctionsFile()->containsPhpCode());
         $this->assertTrue($this->getInlineHtmlFile()->containsPhpCode());
         $this->assertTrue($this->getNamespacedClassFile()->containsPhpCode());
         $this->assertTrue($this->getNonNamespacedClassFile()->containsPhpCode());
@@ -123,6 +123,12 @@ class ReflectionFileTest extends TestCase
     public function testGetClass()
     {
         $this->assertEquals(ClassWithEchoStatement::class, $this->getClassWithEchoStatementFile()->getClass()->getName());
+
+        try {
+            $this->getFunctionsFile()->getClass();
+            $this->fail('Expected exception');
+        } catch (ReflectionException $e) {
+        }
 
         try {
             $this->getInlineHtmlFile()->getClass();
@@ -145,9 +151,47 @@ class ReflectionFileTest extends TestCase
         }
     }
 
+    public function testContainsFunctions()
+    {
+        $this->assertFalse($this->getClassWithEchoStatementFile()->containsFunctions());
+        $this->assertTrue($this->getFunctionsFile()->containsFunctions());
+        $this->assertFalse($this->getInlineHtmlFile()->containsFunctions());
+        $this->assertFalse($this->getNamespacedClassFile()->containsFunctions());
+        $this->assertFalse($this->getNonNamespacedClassFile()->containsFunctions());
+        $this->assertFalse($this->getNonPhpContentFile()->containsFunctions());
+        $this->assertFalse($this->getOutputPrintingFile()->containsFunctions());
+    }
+
+    public function testGetFunctions()
+    {
+        $this->assertEquals([], $this->getClassWithEchoStatementFile()->getFunctions());
+
+        $functions = $this->getFunctionsFile()->getFunctions();
+        $this->assertNotEmpty($functions);
+        $this->assertCount(2, $functions);
+        $this->assertContainsOnlyInstancesOf(\ReflectionFunction::class, $functions);
+        foreach ($functions as $function) {
+            $this->assertContains($function->getName(), [
+                'Rikudou\Tests\Data\myFunction1',
+                'Rikudou\Tests\Data\myFunction2',
+            ]);
+        }
+
+        $this->assertEquals([], $this->getInlineHtmlFile()->getFunctions());
+        $this->assertEquals([], $this->getNamespacedClassFile()->getFunctions());
+        $this->assertEquals([], $this->getNonNamespacedClassFile()->getFunctions());
+        $this->assertEquals([], $this->getNonPhpContentFile()->getFunctions());
+        $this->assertEquals([], $this->getOutputPrintingFile()->getFunctions());
+    }
+
     private function getClassWithEchoStatementFile()
     {
         return $this->getReflection('ClassWithEchoStatement.php');
+    }
+
+    private function getFunctionsFile()
+    {
+        return $this->getReflection('FunctionsFile.php');
     }
 
     private function getInlineHtmlFile()


### PR DESCRIPTION
It should return true only if the file prints something in the outermost scope.